### PR TITLE
Bug fix for alert model return nil value

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -11,7 +11,7 @@ class Alert < ActiveRecord::Base
   validates :description, :creator, presence: true
 
   def self.by_location(radius, location)
-    @all_alerts = Location.within(radius, :origin => location).where(locatable_type: 'Alert').map {|curr_locale| curr_locale.locatable if curr_locale.locatable.status == "incomplete"  }
+    @all_alerts = Location.within(radius, :origin => location).where(locatable_type: 'Alert').map {|curr_locale| curr_locale.locatable if curr_locale.locatable.status == "incomplete"  }.compact
   end
 
 


### PR DESCRIPTION
by location in the alert model returns a nil value if something has been completed.  Calling compact on the method squashes out all the possible nil values.
